### PR TITLE
Do not close stdin

### DIFF
--- a/cmd_publish.go
+++ b/cmd_publish.go
@@ -37,14 +37,16 @@ func (cp *cmdPublish) run(ctx context.Context, argv []string, outStream io.Write
 		return err
 	}
 
-	var r io.ReadCloser = os.Stdin
+	var r io.Reader = os.Stdin
 	if mdFile != "" {
 		var err error
-		if r, err = os.Open(mdFile); err != nil {
+		f, err := os.Open(mdFile)
+		if err != nil {
 			return err
 		}
+		defer f.Close()
+		r = f
 	}
-	defer r.Close()
 
 	m, err := kibela.NewMD(mdFile, r, *title, *coEdit, *dir)
 	if err != nil {


### PR DESCRIPTION
Closing stdin is not guaranteed correct across every possible operating system. Generally, it should be avoided. (except if the process will be terminated immediately)

https://pubs.opengroup.org/onlinepubs/9699919799/functions/fclose.html
