### PR TITLE
drop User.AvatarImage

### DIFF
--- a/kibela/query.go
+++ b/kibela/query.go
@@ -30,9 +30,6 @@ func getNoteQuery(id ID) string {
     }
     author {
       account
-      avatarImage {
-        url
-      }
     }
     updatedAt
     publishedAt
@@ -183,9 +180,6 @@ func getCommentQuery(id ID) string {
   comment(id: "%s") {
     author {
       account
-      avatarImage {
-        url
-      }
     }
     content
     publishedAt

--- a/kibela/user.go
+++ b/kibela/user.go
@@ -1,9 +1,6 @@
 package kibela
 
 type User struct {
-	ID          `json:"id"`
-	Account     string `json:"account"`
-	AvatarImage struct {
-		URL string `json:"url"`
-	} `json:"avatarImage"`
+	ID      `json:"id"`
+	Account string `json:"account"`
 }


### PR DESCRIPTION
AvatarImageで取得できるURLはpublicなものでは無いためあまり取得しても嬉しくないので取るのをやめる。