### PR TITLE
fix cursor format

### DIFF
--- a/kibela/query.go
+++ b/kibela/query.go
@@ -44,7 +44,7 @@ func buildNotesArg(num int, folderID ID, cursor string, hasLimit bool) string {
 	fmt.Fprintf(buf, "first: %d", num)
 	if cursor != "" {
 		// cursor is base64 encoded number. ex. "Nw" = 7
-		fmt.Fprintf(buf, ", after: %s", cursor)
+		fmt.Fprintf(buf, `, after: "%s"`, cursor)
 	}
 	if !folderID.Empty() {
 		fmt.Fprintf(buf, `, folderId: "%s"`, folderID.Raw())


### PR DESCRIPTION
if provide cursor to query, failed graphql request.
cursor param type is string but not specified collect format.

```
[kibelasync] failed to retrieve budgets from response: unexpected end of JSON input
[kibelasync] failed to ki.pullFullNotes: Argument 'after' on Field 'notes' has an invalid value (MTAw). Expected type 'String'.
```

this patch fixes this issue.